### PR TITLE
Simplified Readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The scoring function is supplied as the Python script `scorch.py`. Its main argu
 Additional options are explained in the function help.
 
 
-## Docking and Scoring Multiple SMILES Ligands Against a Single PDBQT Receptor
+## Docking and Scoring SMILES ligands against a receptor
 
 The module includes a full pipeline to convert SMILES ligands to `.pdbqt` files using MGLTools 1.5.6, dock them using GWOVina, and score them with SCORCH:
 


### PR DESCRIPTION
I have tried to further simplify the Readme file. There are just two cases: dock and score, or just score.

I have also removed the part on format conversions, as that should not be necessary if we implement the adjustments I suggest for parsing `-ref_ligand`.

Please check about the `-return_pose_scores` flag. I am not sure if this was implemented in the end, or if it always returns the scores for all individual poses of a ligand.

Thank you